### PR TITLE
[hotfix] GET /v1/statuses/{id}のerror handling

### DIFF
--- a/app/handler/statuses/findbyid.go
+++ b/app/handler/statuses/findbyid.go
@@ -11,7 +11,7 @@ import (
 func (h *handler) FindByID(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "invalid parameter", http.StatusBadRequest)
 		return
 	}
 
@@ -22,7 +22,7 @@ func (h *handler) FindByID(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if dto.Status == nil {
+	if dto == nil {
 		http.Error(w, "status not found", http.StatusNotFound)
 		return
 	}

--- a/app/usecase/status.go
+++ b/app/usecase/status.go
@@ -50,6 +50,9 @@ func (s *status) FindByID(ctx context.Context, id int64) (*GetStatusDTO, error) 
 	if err != nil {
 		return nil, err
 	}
+	if status == nil {
+		return nil, nil
+	}
 
 	account, err := s.acccountRepo.FindByID(ctx, status.AccountID)
 	if err != nil {


### PR DESCRIPTION
# Issue へのリンク

Resolve #12 

# やったこと

- 無効なパラメータが入力された場合や404を正しく表示させるようにする

## 無効なパラメータ
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/73db3be7-d3f8-49df-bd1e-227e7433c5f2">

## IDが存在しない場合
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/b509625c-f9ad-41b2-89d2-c4281f096c5e">


