### PR TITLE
[hotfix] golangciのerrcheckを有効化

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   disable-all: true
   enable:
-    # - errcheck # MEMO: 今回は一旦無効化
+    - errcheck
     - gosimple
     - govet
     - ineffassign

--- a/app/usecase/account.go
+++ b/app/usecase/account.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"log"
 	"yatter-backend-go/app/domain/object"
 	"yatter-backend-go/app/domain/repository"
 
@@ -64,10 +65,14 @@ func (a *account) Create(ctx context.Context, username, password string) (*Creat
 
 	defer func() {
 		if err := recover(); err != nil {
-			tx.Rollback()
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Printf("tx.Rollback() failed: %v", rbErr)
+			}
 		}
 
-		tx.Commit()
+		if err := tx.Commit(); err != nil {
+			log.Printf("tx.Commit() failed: %v", err)
+		}
 	}()
 
 	if err := a.accountRepo.Create(ctx, tx, acc); err != nil {
@@ -105,10 +110,14 @@ func (a *account) Update(ctx context.Context, id int64, display_name, note, avat
 
 	defer func() {
 		if err := recover(); err != nil {
-			tx.Rollback()
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Printf("tx.Rollback() failed: %v", rbErr)
+			}
 		}
 
-		tx.Commit()
+		if err := tx.Commit(); err != nil {
+			log.Printf("tx.Commit() failed: %v", err)
+		}
 	}()
 
 	if err := a.accountRepo.Update(ctx, tx, acc); err != nil {

--- a/app/usecase/status.go
+++ b/app/usecase/status.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"log"
 	"time"
 	"yatter-backend-go/app/domain/object"
 	"yatter-backend-go/app/domain/repository"
@@ -83,12 +84,15 @@ func (s *status) Create(ctx context.Context, account_id int64, content string) (
 	}
 
 	defer func() {
-		if err != nil {
-			tx.Rollback()
-			return
+		if err := recover(); err != nil {
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Printf("tx.Rollback() failed: %v", rbErr)
+			}
 		}
 
-		tx.Commit()
+		if err := tx.Commit(); err != nil {
+			log.Printf("tx.Commit() failed: %v", err)
+		}
 	}()
 
 	if err := s.statusRepo.Create(ctx, tx, status); err != nil {


### PR DESCRIPTION
# Issue へのリンク

Resolve #16 

# やったこと

- golangciのerrcheckを有効化する
- lintが落ちないようにtransaction関係のエラーハンドリングを追加
